### PR TITLE
Fix for EUCA-5921: Windows computer rename issue

### DIFF
--- a/EucaServiceLibrary/EucaServiceLibrary.cs
+++ b/EucaServiceLibrary/EucaServiceLibrary.cs
@@ -236,7 +236,9 @@ namespace Com.Eucalyptus.Windows.EucaServiceLibrary
 
             try
             {
-                HostnameManager.Instance.UpdateHostname(Configuration);
+                if (EucaConstant.JustLaunched)
+                    HostnameManager.Instance.UpdateHostname(Configuration);
+                
                 if (_rebootRequired)
                 {
                     EucaLogger.Info("The system is now rebooting");


### PR DESCRIPTION
This fix addresses the use case where users want to rename instances
after they have been launched on Eucalyptus.  After changing the
computer name in a Windows instance, the instance needs to be rebooted
for the rename to take effect.  The fix makes sure that it checks to see
if the instance was just launched or not.  This fix should work with
instances bound to Active Directory as well, since Active Directory
relies on the SID and not the computer name of the computer object.
Special thanks to Deependra Shekhawat for helping with the solution and
testing of this patch.
