### PR TITLE
Changes "AD Address" to "AD Domain" in Win Integration Tool - EUCA-5960

### DIFF
--- a/AdminGUI/Form1.Designer.cs
+++ b/AdminGUI/Form1.Designer.cs
@@ -368,7 +368,7 @@ namespace Com.Eucalyptus.Windows
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(100, 20);
             this.label1.TabIndex = 100;
-            this.label1.Text = "AD Address";
+            this.label1.Text = "AD Domain";
             this.label1.TextAlign = System.Drawing.ContentAlignment.TopCenter;
             // 
             // buttonApply


### PR DESCRIPTION
This fix changes the text in the Windows Integration Tool from "AD
Address" to "AD Domain" so that users put in the Active Directory Domain
Name instead of the IP or DNS name of the Active Directory Domain
Controller.
