### PR TITLE
Changed "AD Address" to "AD Domain" - EUCA-5960.

### DIFF
--- a/AdminGUI/Form1.Designer.cs
+++ b/AdminGUI/Form1.Designer.cs
@@ -368,7 +368,7 @@ namespace Com.Eucalyptus.Windows
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(100, 20);
             this.label1.TabIndex = 100;
-            this.label1.Text = "AD Address";
+            this.label1.Text = "AD Domain";
             this.label1.TextAlign = System.Drawing.ContentAlignment.TopCenter;
             // 
             // buttonApply


### PR DESCRIPTION
This fix helps communicate that the Windows Integration tool, when configuring the Active Directory section, to use the Active Directory domain instead of the IP/DNS name of the Active Directory Domain Controller.
